### PR TITLE
Solution to Issue #18

### DIFF
--- a/EntityLib/EntityLibCore.cpp
+++ b/EntityLib/EntityLibCore.cpp
@@ -23,35 +23,11 @@ namespace Ent
 #endif
     }
 
-    char const* formatPath(
-        [[maybe_unused]] std::filesystem::path const& _basePath, std::filesystem::path const& _rel)
-    {
-        thread_local static char buffer[2048];
-        snprintf(buffer, sizeof(buffer), R"("%s")", _rel.generic_string().c_str());
-        return buffer;
-    }
-
     Exception::Exception(char const* _message)
         : std::runtime_error(_message)
     {
     }
 
-    FileSystemError::FileSystemError(
-        std::string const& _msg,
-        std::filesystem::path const& _rootPath,
-        std::filesystem::path const& _relPath,
-        std::error_code _error)
-        : ContextException(makeWhatMessage(_msg, _rootPath, _relPath, _error))
-    {
-    }
-    FileSystemError::FileSystemError(
-        std::string const& _msg,
-        std::filesystem::path const& _rootPath,
-        std::filesystem::path const& _relPath)
-        : FileSystemError(
-            _msg, _rootPath, _relPath, std::make_error_code(static_cast<std::errc>(errno)))
-    {
-    }
 
     BadType::BadType(char const* _message)
         : ContextException(_message == nullptr ? "Bad node type" : _message)

--- a/EntityLib/Exception.h
+++ b/EntityLib/Exception.h
@@ -20,7 +20,8 @@ namespace std
 
 #undef COMPILER_VERSION
 
-namespace Ent{
+namespace Ent
+{
 
     char const* formatPath(std::filesystem::path const& _base, std::filesystem::path const& _rel);
 

--- a/EntityLib/Exception.h
+++ b/EntityLib/Exception.h
@@ -113,7 +113,7 @@ void ContextException::addContextMessage(char const* _message, Args&&... args) n
     }
 
     inline ToolsException::ToolsException(char const* _message) noexcept
-        : std::runtime_error(_message)
+        : std::runtime_error(_message == nullptr ? "" : _message)
     {
     }
 

--- a/EntityLib/Exception.h
+++ b/EntityLib/Exception.h
@@ -20,244 +20,247 @@ namespace std
 
 #undef COMPILER_VERSION
 
-char const* formatPath(std::filesystem::path const& _base, std::filesystem::path const& _rel);
+namespace Ent{
 
-struct ToolsException : std::runtime_error
-{
-    ToolsException(char const* _message = nullptr) noexcept;
-};
+    char const* formatPath(std::filesystem::path const& _base, std::filesystem::path const& _rel);
 
-/// An exception allowing to catch + add info + rethrow
-struct ContextException : ToolsException
-{
-    ContextException() noexcept;
-    template <typename... Args>
-    ContextException(char const* _message, Args&&... _args) noexcept;
-    ContextException(char const* _message) noexcept;
-    ContextException(std::string const& _message) noexcept;
-    void addContextMessage(std::string const& _message) noexcept;
-    template <typename... Args>
-    void addContextMessage(char const* _message, Args&&... _args) noexcept;
-
-    const char* what() const noexcept override;
-
-private:
-    // It is better to avoid allocation in error managment because it can lead to throw error above error
-    // BUT the json lib can generete some huge error messages and we need to forward them
-    // so for now we will use dynamic allocation.
-    std::vector<std::vector<char>> m_rawContext;
-};
-
-template <typename... Args>
-ContextException::ContextException(char const* message, Args&&... args) noexcept
-{
-    addContextMessage(message, std::forward<Args>(args)...);
-}
-
-template <typename... Args>
-void ContextException::addContextMessage(char const* _message, Args&&... args) noexcept
-{
-    try
+    struct ToolsException : std::runtime_error
     {
-        auto const written = snprintf(nullptr, 0, _message, std::forward<Args>(args)...);
-        m_rawContext.emplace_back(written + 1);
-        snprintf(
-            m_rawContext.back().data(),
-            m_rawContext.back().size(),
-            _message,
-            std::forward<Args>(args)...);
+        ToolsException(char const* _message = nullptr) noexcept;
+    };
+
+    /// An exception allowing to catch + add info + rethrow
+    struct ContextException : ToolsException
+    {
+        ContextException() noexcept;
+        template <typename... Args>
+        ContextException(char const* _message, Args&&... _args) noexcept;
+        ContextException(char const* _message) noexcept;
+        ContextException(std::string const& _message) noexcept;
+        void addContextMessage(std::string const& _message) noexcept;
+        template <typename... Args>
+        void addContextMessage(char const* _message, Args&&... _args) noexcept;
+
+        const char* what() const noexcept override;
+
+    private:
+        // It is better to avoid allocation in error managment because it can lead to throw error above error
+        // BUT the json lib can generete some huge error messages and we need to forward them
+        // so for now we will use dynamic allocation.
+        std::vector<std::vector<char>> m_rawContext;
+    };
+
+    template <typename... Args>
+    ContextException::ContextException(char const* message, Args&&... args) noexcept
+    {
+        addContextMessage(message, std::forward<Args>(args)...);
     }
-    catch (std::bad_alloc&)
-    {
-    }
-}
 
-/// A ContextException which is wrapping an external
-/// Usefull to add some context info on an exception which in not a ContextException
-struct WrapperException : ContextException
-{
-    std::exception_ptr exptr;
     template <typename... Args>
-    WrapperException(std::exception_ptr const& _exptr, char const* _message, Args&&... _args) noexcept;
-};
-
-/// Use FileSystemError rather than filesystem_error, since
-///     - It will convert the message charset into utf8
-///     - It will print the path as expected in Wild tools
-struct FileSystemError : ContextException
-{
-    FileSystemError(
-        std::string const& _msg,
-        std::filesystem::path const& _rootPath,
-        std::filesystem::path const& _relPath,
-        std::error_code _error);
-
-    /// This ctor will use the errno as error_code
-    FileSystemError(
-        std::string const& _msg,
-        std::filesystem::path const& _rootPath,
-        std::filesystem::path const& _relPath);
-};
-
-// *************************************** bodies *************************************************
-
-inline char const* formatPath(
-    std::filesystem::path const&, //_base,
-    std::filesystem::path const& _rel)
-{
-    thread_local static char buffer[2048];
-    snprintf(buffer, sizeof(buffer), R"("%s")", _rel.generic_string().c_str());
-    return buffer;
-}
-
-inline ToolsException::ToolsException(char const* _message) noexcept
-    : std::runtime_error(_message)
-{
-}
-
-inline ContextException::ContextException() noexcept = default;
-
-inline ContextException::ContextException(char const* _message) noexcept
-    : ToolsException(_message)
-{
-    addContextMessage(_message);
-}
-
-inline ContextException::ContextException(std::string const& _message) noexcept
-    : ContextException(_message.c_str())
-{
-}
-
-inline void ContextException::addContextMessage(std::string const& _message) noexcept
-{
-    addContextMessage(_message.c_str());
-}
-
-inline const char* ContextException::what() const noexcept
-{
-    thread_local static std::string buffer;
-    try
+    void ContextException::addContextMessage(char const* _message, Args&&... args) noexcept
     {
-
-        buffer.clear();
-        bool first = true;
-        for (auto& message : m_rawContext)
+        try
         {
-            if (!first)
-            {
-                buffer += "    - ";
-            }
-            buffer += message.data();
-            buffer += "\n";
-            first = false;
+            auto const written = snprintf(nullptr, 0, _message, std::forward<Args>(args)...);
+            m_rawContext.emplace_back(written + 1);
+            snprintf(
+                m_rawContext.back().data(),
+                m_rawContext.back().size(),
+                _message,
+                std::forward<Args>(args)...);
+        }
+        catch (std::bad_alloc&)
+        {
         }
     }
-    catch (std::bad_alloc&)
+
+    /// A ContextException which is wrapping an external
+    /// Usefull to add some context info on an exception which in not a ContextException
+    struct WrapperException : ContextException
+    {
+        std::exception_ptr exptr;
+        template <typename... Args>
+        WrapperException(std::exception_ptr const& _exptr, char const* _message, Args&&... _args) noexcept;
+    };
+
+    /// Use FileSystemError rather than filesystem_error, since
+    ///     - It will convert the message charset into utf8
+    ///     - It will print the path as expected in Wild tools
+    struct FileSystemError : ContextException
+    {
+        FileSystemError(
+            std::string const& _msg,
+            std::filesystem::path const& _rootPath,
+            std::filesystem::path const& _relPath,
+            std::error_code _error);
+
+        /// This ctor will use the errno as error_code
+        FileSystemError(
+            std::string const& _msg,
+            std::filesystem::path const& _rootPath,
+            std::filesystem::path const& _relPath);
+    };
+
+    // *************************************** bodies *************************************************
+
+    inline char const* formatPath(
+        std::filesystem::path const&, //_base,
+        std::filesystem::path const& _rel)
+    {
+        thread_local static char buffer[2048];
+        snprintf(buffer, sizeof(buffer), R"("%s")", _rel.generic_string().c_str());
+        return buffer;
+    }
+
+    inline ToolsException::ToolsException(char const* _message) noexcept
+        : std::runtime_error(_message)
     {
     }
-    return buffer.data();
-}
 
-template <typename... Args>
-inline WrapperException::WrapperException(
-    std::exception_ptr const& _exptr, char const* _message, Args&&... _args) noexcept
-    : exptr(_exptr)
-{
-    try
+    inline ContextException::ContextException() noexcept = default;
+
+    inline ContextException::ContextException(char const* _message) noexcept
+        : ToolsException(_message)
     {
-        std::rethrow_exception(exptr);
+        addContextMessage(_message);
     }
-    catch (std::exception& ex)
+
+    inline ContextException::ContextException(std::string const& _message) noexcept
+        : ContextException(_message.c_str())
     {
-        addContextMessage("%s : %s", typeid(ex).name(), ex.what());
     }
-    catch (...)
+
+    inline void ContextException::addContextMessage(std::string const& _message) noexcept
     {
-        addContextMessage("Unknown exception");
+        addContextMessage(_message.c_str());
     }
-    addContextMessage(_message, std::forward<Args>(_args)...);
-}
 
-#ifdef _WIN32
-extern "C"
-{
-    __declspec(dllimport) int MultiByteToWideChar(
-        unsigned int CodePage,
-        unsigned long dwFlags,
-        char const* lpMultiByteStr,
-        int cbMultiByte,
-        wchar_t* lpWideCharStr,
-        int cchWideChar);
+    inline const char* ContextException::what() const noexcept
+    {
+        thread_local static std::string buffer;
+        try
+        {
 
-    __declspec(dllimport) int WideCharToMultiByte(
-        unsigned int CodePage,
-        unsigned long dwFlags,
-        wchar_t const* lpWideCharStr,
-        int cchWideChar,
-        char* lpMultiByteStr,
-        int cbMultiByte,
-        char const* lpDefaultChar,
-        int* lpUsedDefaultChar);
-}
+            buffer.clear();
+            bool first = true;
+            for (auto& message : m_rawContext)
+            {
+                if (!first)
+                {
+                    buffer += "    - ";
+                }
+                buffer += message.data();
+                buffer += "\n";
+                first = false;
+            }
+        }
+        catch (std::bad_alloc&)
+        {
+        }
+        return buffer.data();
+    }
 
-inline std::string convertANSIToUTF8(std::string const& message)
-{
-    // CP_ACP is the system default Windows ANSI code page.
-    constexpr auto AnsiCodePage = 0;
-    constexpr auto Utf8CodePage = 65001;
-    // ANSI to utf16
-    int convertResult =
-        MultiByteToWideChar(AnsiCodePage, 0, message.c_str(), (int)message.size(), nullptr, 0);
-    std::wstring wide;
-    wide.resize((size_t)convertResult);
-    MultiByteToWideChar(
-        AnsiCodePage, 0, message.c_str(), (int)message.size(), &wide[0], (int)wide.size());
-    // utf16 to utf8
-    convertResult = WideCharToMultiByte(
-        Utf8CodePage, 0, wide.c_str(), (int)wide.size(), nullptr, 0, nullptr, nullptr);
-    std::string result;
-    result.resize((size_t)convertResult);
-    WideCharToMultiByte(
-        Utf8CodePage, 0, wide.c_str(), (int)wide.size(), &result[0], (int)result.size(), nullptr, nullptr);
-    result.resize((size_t)convertResult);
-    return result;
-}
-#else
-inline std::string convertANSIToUTF8(std::string message)
-{
-    return message;
-}
-#endif
+    template <typename... Args>
+    inline WrapperException::WrapperException(
+        std::exception_ptr const& _exptr, char const* _message, Args&&... _args) noexcept
+        : exptr(_exptr)
+    {
+        try
+        {
+            std::rethrow_exception(exptr);
+        }
+        catch (std::exception& ex)
+        {
+            addContextMessage("%s : %s", typeid(ex).name(), ex.what());
+        }
+        catch (...)
+        {
+            addContextMessage("Unknown exception");
+        }
+        addContextMessage(_message, std::forward<Args>(_args)...);
+    }
 
-inline char const* makeWhatMessage(
-    std::string const& msg,
-    std::filesystem::path const& rootPath,
-    std::filesystem::path const& relPath,
-    std::error_code error)
-{
-    static constexpr auto InitBuffSize = 4096;
-    thread_local static char buffer[InitBuffSize] = {0};
-    snprintf(
-        buffer,
-        InitBuffSize,
-        R"msg(%s - %s : %s)msg",
-        msg.c_str(),
-        convertANSIToUTF8(error.message()).c_str(),
-        formatPath(rootPath, relPath));
-    return buffer;
-}
+    #ifdef _WIN32
+    extern "C"
+    {
+        __declspec(dllimport) int MultiByteToWideChar(
+            unsigned int CodePage,
+            unsigned long dwFlags,
+            char const* lpMultiByteStr,
+            int cbMultiByte,
+            wchar_t* lpWideCharStr,
+            int cchWideChar);
 
-inline FileSystemError::FileSystemError(
-    std::string const& msg,
-    std::filesystem::path const& rootPath,
-    std::filesystem::path const& relPath,
-    std::error_code error)
-    : ContextException(makeWhatMessage(msg, rootPath, relPath, error))
-{
-}
+        __declspec(dllimport) int WideCharToMultiByte(
+            unsigned int CodePage,
+            unsigned long dwFlags,
+            wchar_t const* lpWideCharStr,
+            int cchWideChar,
+            char* lpMultiByteStr,
+            int cbMultiByte,
+            char const* lpDefaultChar,
+            int* lpUsedDefaultChar);
+    }
 
-inline FileSystemError::FileSystemError(
-    std::string const& msg, std::filesystem::path const& rootPath, std::filesystem::path const& relPath)
-    : FileSystemError(msg, rootPath, relPath, std::make_error_code(static_cast<std::errc>(errno)))
-{
+    inline std::string convertANSIToUTF8(std::string const& message)
+    {
+        // CP_ACP is the system default Windows ANSI code page.
+        constexpr auto AnsiCodePage = 0;
+        constexpr auto Utf8CodePage = 65001;
+        // ANSI to utf16
+        int convertResult =
+            MultiByteToWideChar(AnsiCodePage, 0, message.c_str(), (int)message.size(), nullptr, 0);
+        std::wstring wide;
+        wide.resize((size_t)convertResult);
+        MultiByteToWideChar(
+            AnsiCodePage, 0, message.c_str(), (int)message.size(), &wide[0], (int)wide.size());
+        // utf16 to utf8
+        convertResult = WideCharToMultiByte(
+            Utf8CodePage, 0, wide.c_str(), (int)wide.size(), nullptr, 0, nullptr, nullptr);
+        std::string result;
+        result.resize((size_t)convertResult);
+        WideCharToMultiByte(
+            Utf8CodePage, 0, wide.c_str(), (int)wide.size(), &result[0], (int)result.size(), nullptr, nullptr);
+        result.resize((size_t)convertResult);
+        return result;
+    }
+    #else
+    inline std::string convertANSIToUTF8(std::string message)
+    {
+        return message;
+    }
+    #endif
+
+    inline char const* makeWhatMessage(
+        std::string const& msg,
+        std::filesystem::path const& rootPath,
+        std::filesystem::path const& relPath,
+        std::error_code error)
+    {
+        static constexpr auto InitBuffSize = 4096;
+        thread_local static char buffer[InitBuffSize] = {0};
+        snprintf(
+            buffer,
+            InitBuffSize,
+            R"msg(%s - %s : %s)msg",
+            msg.c_str(),
+            convertANSIToUTF8(error.message()).c_str(),
+            formatPath(rootPath, relPath));
+        return buffer;
+    }
+
+    inline FileSystemError::FileSystemError(
+        std::string const& msg,
+        std::filesystem::path const& rootPath,
+        std::filesystem::path const& relPath,
+        std::error_code error)
+        : ContextException(makeWhatMessage(msg, rootPath, relPath, error))
+    {
+    }
+
+    inline FileSystemError::FileSystemError(
+        std::string const& msg, std::filesystem::path const& rootPath, std::filesystem::path const& relPath)
+        : FileSystemError(msg, rootPath, relPath, std::make_error_code(static_cast<std::errc>(errno)))
+    {
+    }
 }

--- a/EntityLib/include/EntityLib/EntityLibCore.h
+++ b/EntityLib/include/EntityLib/EntityLibCore.h
@@ -330,23 +330,6 @@ namespace Ent
         explicit InvalidJsonData(char const* _message); ///< ctor
     };
 
-    /// Use FileSystemError rather than filesystem_error, since
-    ///     - It will convert the message charset into utf8
-    ///     - It will print the path as expected in Wild tools
-    struct FileSystemError : ContextException
-    {
-        FileSystemError(
-            std::string const& _msg,
-            std::filesystem::path const& _rootPath,
-            std::filesystem::path const& _relPath,
-            std::error_code _error);
-
-        /// This ctor will use the errno as error_code
-        FileSystemError(
-            std::string const& _msg,
-            std::filesystem::path const& _rootPath,
-            std::filesystem::path const& _relPath);
-    };
 
     /// Exception thrown when some json data are invalid
     struct CantRename : ContextException


### PR DESCRIPTION
Enclosed the Exeception.h body into namespace Ent

Removed the redefinition of Ent::FileSystemError in EntityLibCore.h, line 336

removed the redefinition of Ent::FileSystemError::FileSystemError in EntityLibCore.cpp, lines 39 and 47

Removed the body redefinition of Ent::formatPath in EntityLibCore.cpp, line 26

Please check my work!